### PR TITLE
DO NOT MERGE - Disable overlay with decor caption default

### DIFF
--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -321,7 +321,12 @@ public abstract class Window {
     @UnsupportedAppUsage
     private boolean mDestroyed;
 
-    private boolean mOverlayWithDecorCaptionEnabled = true;
+    // region @boringdroid
+    // Disable overlay with decor caption default, before we find why the system missed
+    // caption bar inset dispatching when window first opened.
+    // private boolean mOverlayWithDecorCaptionEnabled = true;
+    private boolean mOverlayWithDecorCaptionEnabled = false;
+    // endregion
     private boolean mCloseOnSwipeEnabled = false;
 
     // The current window attributes.


### PR DESCRIPTION
Before we find why the system missed caption bar inset dispatching when
window first opened, we should keep it disabled.

resolves BOR-16