### PR TITLE
Port captionbar overlay patch from S

### DIFF
--- a/core/java/android/view/InsetsController.java
+++ b/core/java/android/view/InsetsController.java
@@ -624,7 +624,7 @@ public class InsetsController implements WindowInsetsController, InsetsAnimation
         updateState(state);
         applyLocalVisibilityOverride();
 
-        if (!mState.equals(lastState, true /* excludingCaptionInsets */,
+        if (!mState.equals(lastState, false /* excludingCaptionInsets */,
                 true /* excludeInvisibleIme */)) {
             if (DEBUG) Log.d(TAG, "onStateChanged, notifyInsetsChanged");
             mHost.notifyInsetsChanged();
@@ -658,15 +658,13 @@ public class InsetsController implements WindowInsetsController, InsetsAnimation
             getSourceConsumer(type).updateSource(source, animationType);
         }
         for (@InternalInsetsType int type = 0; type < InsetsState.SIZE; type++) {
+            // Only update the server side insets here.
+            if (type == ITYPE_CAPTION_BAR) continue;
             InsetsSource source = mState.peekSource(type);
             if (source == null) continue;
             if (newState.peekSource(type) == null) {
                 mState.removeSource(type);
             }
-        }
-        if (mCaptionInsetsHeight != 0) {
-            mState.getSource(ITYPE_CAPTION_BAR).setFrame(new Rect(mFrame.left, mFrame.top,
-                    mFrame.right, mFrame.top + mCaptionInsetsHeight));
         }
 
         updateDisabledUserAnimationTypes(disabledUserAnimationTypes);
@@ -1374,7 +1372,16 @@ public class InsetsController implements WindowInsetsController, InsetsAnimation
 
     @Override
     public void setCaptionInsetsHeight(int height) {
-        mCaptionInsetsHeight = height;
+        if (mCaptionInsetsHeight != height) {
+            mCaptionInsetsHeight = height;
+            if (mCaptionInsetsHeight != 0) {
+                mState.getSource(ITYPE_CAPTION_BAR).setFrame(new Rect(mFrame.left, mFrame.top,
+                        mFrame.right, mFrame.top + mCaptionInsetsHeight));
+            } else {
+                mState.removeSource(ITYPE_CAPTION_BAR);
+            }
+            mHost.notifyInsetsChanged();
+        }
     }
 
     @Override

--- a/core/java/android/view/Window.java
+++ b/core/java/android/view/Window.java
@@ -321,12 +321,7 @@ public abstract class Window {
     @UnsupportedAppUsage
     private boolean mDestroyed;
 
-    // region @boringdroid
-    // Disable overlay with decor caption default, before we find why the system missed
-    // caption bar inset dispatching when window first opened.
-    // private boolean mOverlayWithDecorCaptionEnabled = true;
-    private boolean mOverlayWithDecorCaptionEnabled = false;
-    // endregion
+    private boolean mOverlayWithDecorCaptionEnabled = true;
     private boolean mCloseOnSwipeEnabled = false;
 
     // The current window attributes.

--- a/core/java/com/android/internal/policy/DecorView.java
+++ b/core/java/com/android/internal/policy/DecorView.java
@@ -2021,6 +2021,7 @@ public class DecorView extends FrameLayout implements RootViewSurfaceTaker, Wind
             if (getForeground() != null) {
                 drawableChanged();
             }
+            notifyCaptionHeightChanged();
         }
     }
 

--- a/core/tests/coretests/src/android/view/InsetsControllerTest.java
+++ b/core/tests/coretests/src/android/view/InsetsControllerTest.java
@@ -44,6 +44,7 @@ import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -689,6 +690,19 @@ public class InsetsControllerTest {
             // The caption bar source should not be there at all, because we don't add empty
             // caption to the state from the server.
             assertNull(mController.getState().peekSource(ITYPE_CAPTION_BAR));
+        });
+    }
+
+    @Test
+    public void testNotifyCaptionInsetsOnlyChange() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+            final InsetsState state = new InsetsState(mController.getState(), true);
+            reset(mTestHost);
+            mController.setCaptionInsetsHeight(100);
+            verify(mTestHost).notifyInsetsChanged();
+            reset(mTestHost);
+            mController.setCaptionInsetsHeight(0);
+            verify(mTestHost).notifyInsetsChanged();
         });
     }
 


### PR DESCRIPTION
Revert old dirty patch, and port real patch from Android S. This patch will help to fix captionbar overlaps when freeform window opened.