### PR TITLE
Support minimize function of multi-window

### DIFF
--- a/core/java/com/android/internal/policy/DecorView.java
+++ b/core/java/com/android/internal/policy/DecorView.java
@@ -2350,6 +2350,10 @@ public class DecorView extends FrameLayout implements RootViewSurfaceTaker, Wind
     }
 
     private void setLightDecorCaptionShade(DecorCaptionView view) {
+        // region @boringdroid
+        view.findViewById(R.id.minimize_window).setBackgroundResource(
+                R.drawable.decor_minimize_button_light);
+        // endregion
         view.findViewById(R.id.maximize_window).setBackgroundResource(
                 R.drawable.decor_maximize_button_light);
         view.findViewById(R.id.close_window).setBackgroundResource(
@@ -2357,6 +2361,10 @@ public class DecorView extends FrameLayout implements RootViewSurfaceTaker, Wind
     }
 
     private void setDarkDecorCaptionShade(DecorCaptionView view) {
+        // region @boringdroid
+        view.findViewById(R.id.minimize_window).setBackgroundResource(
+                R.drawable.decor_minimize_button_dark);
+        // endregion
         view.findViewById(R.id.maximize_window).setBackgroundResource(
                 R.drawable.decor_maximize_button_dark);
         view.findViewById(R.id.close_window).setBackgroundResource(

--- a/core/java/com/android/internal/widget/DecorCaptionView.java
+++ b/core/java/com/android/internal/widget/DecorCaptionView.java
@@ -16,6 +16,7 @@
 
 package com.android.internal.widget;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
 import android.util.AttributeSet;
@@ -136,6 +137,9 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
         // background without removing the shadow.
         mOwner.getDecorView().setOutlineProvider(ViewOutlineProvider.BOUNDS);
         mMaximize = findViewById(R.id.maximize_window);
+        // region @boringdroid
+        mMinimize = findViewById(R.id.minimize_window);
+        // endregion
         mClose = findViewById(R.id.close_window);
     }
 
@@ -150,6 +154,11 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
             if (mMaximizeRect.contains(x, y - mRootScrollY)) {
                 mClickTarget = mMaximize;
             }
+            // region @boringdroid
+            if (mMinimizeRect.contains(x, y - mRootScrollY)) {
+                mClickTarget = mMinimize;
+            }
+            // endregion
             if (mCloseRect.contains(x, y - mRootScrollY)) {
                 mClickTarget = mClose;
             }
@@ -287,9 +296,15 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
             mCaption.layout(0, 0, mCaption.getMeasuredWidth(), mCaption.getMeasuredHeight());
             captionHeight = mCaption.getBottom() - mCaption.getTop();
             mMaximize.getHitRect(mMaximizeRect);
+            // region @boringdroid
+            mMinimize.getHitRect(mMinimizeRect);
+            // endregion
             mClose.getHitRect(mCloseRect);
         } else {
             captionHeight = 0;
+	    // region @boringdroid
+	    mMinimizeRect.setEmpty();
+	    // endregion
             mMaximizeRect.setEmpty();
             mCloseRect.setEmpty();
         }
@@ -306,8 +321,12 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
         ((DecorView) mOwner.getDecorView()).notifyCaptionHeightChanged();
 
         // This assumes that the caption bar is at the top.
-        mOwner.notifyRestrictedCaptionAreaCallback(mMaximize.getLeft(), mMaximize.getTop(),
+        // region @boringdroid
+        // mOwner.notifyRestrictedCaptionAreaCallback(mMaximize.getLeft(), mMaximize.getTop(),
+        //         mClose.getRight(), mClose.getBottom());
+        mOwner.notifyRestrictedCaptionAreaCallback(mMinimize.getLeft(), mMinimize.getTop(),
                 mClose.getRight(), mClose.getBottom());
+        // endregion
     }
 
     /**
@@ -380,6 +399,15 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
 
     @Override
     public boolean onSingleTapUp(MotionEvent e) {
+        // region @boringdroid
+        if (mClickTarget == mMinimize) {
+            Context context = getContext();
+            if (context instanceof Activity) {
+                Activity activity = (Activity) context;
+                return activity.moveTaskToBack(true);
+            }
+        }
+        // endregion
         if (mClickTarget == mMaximize) {
             toggleFreeformWindowingMode();
         } else if (mClickTarget == mClose) {
@@ -403,6 +431,9 @@ public class DecorCaptionView extends ViewGroup implements View.OnTouchListener,
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         return false;
     }
+    // region @boringdroid
+    private View mMinimize;
+    private final Rect mMinimizeRect = new Rect();
 
     /**
      * Called when {@link android.view.ViewRootImpl} scrolls for adjustPan.

--- a/core/res/res/drawable/decor_minimize_button_dark.xml
+++ b/core/res/res/drawable/decor_minimize_button_dark.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2015 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="32.0dp"
+        android:height="32.0dp"
+        android:viewportWidth="32.0"
+        android:viewportHeight="32.0"
+        android:tint="@color/decor_button_dark_color">
+    <group android:scaleX="0.5"
+           android:scaleY="0.5"
+           android:translateX="8.0"
+           android:translateY="8.0">
+        <path android:fillColor="@color/white"
+              android:pathData="M14.0,10.0l0.0,4.0,l20.0,0.0l0.0,-4.0z"/>
+    </group>
+</vector>
+
+

--- a/core/res/res/drawable/decor_minimize_button_light.xml
+++ b/core/res/res/drawable/decor_minimize_button_light.xml
@@ -1,0 +1,30 @@
+<!--
+Copyright (C) 2015 The Android Open Source Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="32.0dp"
+        android:height="32.0dp"
+        android:viewportWidth="32.0"
+        android:viewportHeight="32.0"
+        android:tint="@color/decor_button_light_color">
+    <group android:scaleX="0.5"
+           android:scaleY="0.5"
+           android:translateX="8.0"
+           android:translateY="8.0">
+        <path android:fillColor="@color/white"
+              android:pathData="M14.0,10.0l0.0,4.0,l20.0,0.0l0.0,-4.0z"/>
+    </group>
+</vector>

--- a/core/res/res/layout/decor_caption.xml
+++ b/core/res/res/layout/decor_caption.xml
@@ -30,6 +30,17 @@
             android:background="@drawable/decor_caption_title"
             android:focusable="false"
             android:descendantFocusability="blocksDescendants" >
+        <!-- region @boringdroid -->
+        <Button
+                android:id="@+id/minimize_window"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_margin="5dp"
+                android:padding="4dp"
+                android:layout_gravity="center_vertical|end"
+                android:contentDescription="@string/minimize_button_text"
+                android:background="@drawable/decor_minimize_button_dark" />
+        <!-- endregion -->
         <Button
                 android:id="@+id/maximize_window"
                 android:layout_width="32dp"

--- a/core/res/res/values/arrays.xml
+++ b/core/res/res/values/arrays.xml
@@ -139,6 +139,10 @@
    <array name="preloaded_freeform_multi_window_drawables">
       <item>@drawable/decor_maximize_button_dark</item>
       <item>@drawable/decor_maximize_button_light</item>
+      <!-- region @boringdroid -->
+      <item>@drawable/decor_minimize_button_dark</item>
+      <item>@drawable/decor_minimize_button_light</item>
+      <!-- endregion -->
    </array>
 
     <!-- Used in LocalePicker -->

--- a/core/res/res/values/strings.xml
+++ b/core/res/res/values/strings.xml
@@ -5385,6 +5385,9 @@
     <!-- Free style window strings -->
     <!-- Accessibility text for the maximize window button -->
     <string name="maximize_button_text">Maximize</string>
+    <!-- region @boringdroid -->
+    <string name="minimize_button_text">Minimize</string>
+    <!-- endregion -->
     <!-- Accessibility text for the close window button -->
     <string name="close_button_text">Close</string>
 

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2414,6 +2414,11 @@
   <java-symbol type="drawable" name="decor_close_button_light" />
   <java-symbol type="drawable" name="decor_maximize_button_dark" />
   <java-symbol type="drawable" name="decor_maximize_button_light" />
+  <!-- region @boringdroid -->
+  <java-symbol type="id" name="minimize_window" />
+  <java-symbol type="drawable" name="decor_minimize_button_dark" />
+  <java-symbol type="drawable" name="decor_minimize_button_light" />
+  <!-- endregion -->
   <java-symbol type="color" name="decor_button_dark_color" />
   <java-symbol type="color" name="decor_button_light_color" />
   <java-symbol type="array" name="unloggable_phone_numbers" />


### PR DESCRIPTION
When minimize icon is clicked, we will use `Activity#moveTaskToBack` method to move Activity's task to back based on z-order.

After minimized, the launcher will launch the origin task of app, and move it to front for many occasion.