### PR TITLE
wmshell: Update window corner radius with resource/dimen

### DIFF
--- a/libs/WindowManager/Shell/res/values/dimen.xml
+++ b/libs/WindowManager/Shell/res/values/dimen.xml
@@ -439,4 +439,7 @@
     <!-- The height of the area at the top of the screen where a freeform task will transition to
     fullscreen if dragged until the top bound of the task is within the area. -->
     <dimen name="desktop_mode_transition_area_height">16dp</dimen>
+    <!-- @boringdroid -->
+    <dimen name="decor_corner_radius">8dp</dimen>
+    <!-- endregion -->
 </resources>

--- a/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecoration.java
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/windowdecor/CaptionWindowDecoration.java
@@ -54,6 +54,9 @@ public class CaptionWindowDecoration extends WindowDecoration<WindowDecorLinearL
     private RelayoutParams mRelayoutParams = new RelayoutParams();
     private final RelayoutResult<WindowDecorLinearLayout> mResult =
             new RelayoutResult<>();
+    // region @boringdroid
+    private int mWindowCornerRadius = 8;
+    // endregion
 
     CaptionWindowDecoration(
             Context context,
@@ -69,6 +72,9 @@ public class CaptionWindowDecoration extends WindowDecoration<WindowDecorLinearL
         mHandler = handler;
         mChoreographer = choreographer;
         mSyncQueue = syncQueue;
+        // region @boringdroid
+        mWindowCornerRadius = (int) context.getResources().getDimension(R.dimen.decor_corner_radius);
+        // endregion
     }
 
     void setCaptionListeners(
@@ -116,6 +122,9 @@ public class CaptionWindowDecoration extends WindowDecoration<WindowDecorLinearL
         mRelayoutParams.mCaptionHeightId = getCaptionHeightId();
         mRelayoutParams.mShadowRadiusId = shadowRadiusID;
         mRelayoutParams.mApplyStartTransactionOnDraw = applyStartTransactionOnDraw;
+        // region @boringdroid
+        mRelayoutParams.mCornerRadius = mWindowCornerRadius;
+        // endregion
 
         relayout(mRelayoutParams, startT, finishT, wct, oldRootView, mResult);
         // After this line, mTaskInfo is up-to-date and should be used instead of taskInfo


### PR DESCRIPTION
It requires ""persist.wm.debug.caption_on_shell" to be true to enable caption in wmshell.

We can use overlay to override added decor_corner_radius for Shell package to customize corner radius of freeform window.